### PR TITLE
Add virtualized datatable component

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,8 @@
         "@angular/forms": "^20.0.0",
         "@angular/platform-browser": "^20.0.0",
         "@angular/router": "^20.0.0",
+        "@tanstack/table-core": "^8.21.3",
+        "@tanstack/virtual-core": "^3.13.12",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
@@ -3191,6 +3193,29 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tanstack/table-core": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
+      "integrity": "sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
     },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,9 @@
     "@angular/router": "^20.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "zone.js": "~0.15.0"
+    "zone.js": "~0.15.0",
+    "@tanstack/table-core": "^8.21.3",
+    "@tanstack/virtual-core": "^3.13.12"
   },
   "devDependencies": {
     "@angular/build": "^20.0.5",

--- a/frontend/src/app/app.html
+++ b/frontend/src/app/app.html
@@ -337,5 +337,6 @@
 <!-- * * * * * * * * * * End of Placeholder  * * * * * * * * * * * * -->
 <!-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * -->
 
+<app-data-table-example></app-data-table-example>
 
 <router-outlet />

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { DataTableExampleComponent } from './datatable/datatable-example.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, DataTableExampleComponent],
   templateUrl: './app.html',
   styleUrl: './app.css'
 })

--- a/frontend/src/app/datatable/data-table.component.css
+++ b/frontend/src/app/datatable/data-table.component.css
@@ -1,0 +1,44 @@
+.table-container {
+  overflow-y: auto;
+  max-height: 400px;
+  position: relative;
+}
+
+.table-container table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  border-bottom: 1px solid #e0e0e0;
+  padding: 4px 8px;
+  box-sizing: border-box;
+  background: white;
+}
+
+th.sticky,
+td.sticky {
+  background: white;
+  z-index: 1;
+}
+
+th {
+  position: sticky;
+  top: 0;
+  background: #f0f0f0;
+}
+
+.header-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: relative;
+}
+
+.resize-handle {
+  width: 5px;
+  cursor: col-resize;
+  user-select: none;
+  touch-action: none;
+}

--- a/frontend/src/app/datatable/data-table.component.html
+++ b/frontend/src/app/datatable/data-table.component.html
@@ -1,0 +1,46 @@
+<div #scroller class="table-container">
+  <table>
+    <thead>
+      <tr *ngFor="let headerGroup of table.getHeaderGroups()" class="header-group">
+        <ng-container *ngFor="let header of headerGroup.headers">
+          <th
+            [attr.colspan]="header.colSpan"
+            [class.placeholder]="header.isPlaceholder"
+            [style.width.px]="header.getSize()"
+            [style.left.px]="header.getStart('left')"
+            [style.right.px]="header.getAfter('right')"
+            [style.position]="header.column.getIsPinned() ? 'sticky' : undefined"
+            class="header-cell"
+          >
+            <div class="header-content">
+              {{ flexRender(header.column.columnDef.header, header.getContext()) }}
+              <span
+                class="resize-handle"
+                *ngIf="header.column.getCanResize()"
+                (mousedown)="header.getResizeHandler()($event)"
+                (touchstart)="header.getResizeHandler()($event)"
+              ></span>
+            </div>
+          </th>
+        </ng-container>
+      </tr>
+    </thead>
+    <tbody [style.height.px]="rowVirtualizer?.getTotalSize()">
+      <tr
+        *ngFor="let row of renderRows; let i = index"
+        [style.transform]="rowVirtualizer ? 'translateY(' + rowVirtualizer.getVirtualItems()[i].start + 'px)' : null"
+      >
+        <ng-container *ngFor="let cell of row.getVisibleCells()">
+          <td
+            [style.width.px]="cell.column.getSize()"
+            [style.left.px]="cell.column.getStart('left')"
+            [style.right.px]="cell.column.getAfter('right')"
+            [style.position]="cell.column.getIsPinned() ? 'sticky' : undefined"
+          >
+            {{ flexRender(cell.column.columnDef.cell, cell.getContext()) }}
+          </td>
+        </ng-container>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/frontend/src/app/datatable/data-table.component.ts
+++ b/frontend/src/app/datatable/data-table.component.ts
@@ -1,0 +1,97 @@
+import { AfterViewInit, Component, ElementRef, Input, OnChanges, SimpleChanges, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import {
+  ColumnDef,
+  Table,
+  createTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getGroupedRowModel,
+  getExpandedRowModel,
+  RowData,
+} from '@tanstack/table-core';
+import {
+  Virtualizer,
+  elementScroll,
+  observeElementRect,
+  observeElementOffset,
+} from '@tanstack/virtual-core';
+
+@Component({
+  selector: 'app-data-table',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './data-table.component.html',
+  styleUrl: './data-table.component.css'
+})
+export class DataTableComponent<T extends RowData> implements AfterViewInit, OnChanges {
+  @Input() data: T[] = [];
+  @Input() columns: ColumnDef<T, any>[] = [];
+
+  @ViewChild('scroller', { static: true }) scroller!: ElementRef<HTMLDivElement>;
+
+  table!: Table<T>;
+  rowVirtualizer?: Virtualizer<HTMLDivElement, Element>;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['data'] || changes['columns']) {
+      this.initTable();
+    }
+  }
+
+  ngAfterViewInit(): void {
+    this.initVirtualizer();
+  }
+
+  private initTable() {
+    this.table = createTable({
+      data: this.data,
+      columns: this.columns,
+      getCoreRowModel: getCoreRowModel(),
+      getFilteredRowModel: getFilteredRowModel(),
+      getSortedRowModel: getSortedRowModel(),
+      getPaginationRowModel: getPaginationRowModel(),
+      getGroupedRowModel: getGroupedRowModel(),
+      getExpandedRowModel: getExpandedRowModel(),
+      enableColumnResizing: true,
+      columnResizeMode: 'onChange',
+      enableColumnPinning: true,
+      state: {},
+      onStateChange: () => {},
+      renderFallbackValue: null,
+    });
+    if (this.rowVirtualizer) {
+      this.rowVirtualizer.setOptions({
+        count: this.table.getRowModel().rows.length,
+        getScrollElement: () => this.scroller.nativeElement,
+        estimateSize: () => 35,
+        scrollToFn: elementScroll,
+        observeElementRect,
+        observeElementOffset,
+      });
+    }
+  }
+
+  private initVirtualizer() {
+    this.rowVirtualizer = new Virtualizer<HTMLDivElement, Element>({
+      count: this.table.getRowModel().rows.length,
+      getScrollElement: () => this.scroller.nativeElement,
+      estimateSize: () => 35,
+      scrollToFn: elementScroll,
+      observeElementRect,
+      observeElementOffset,
+    });
+  }
+
+  get renderRows() {
+    if (!this.rowVirtualizer) return this.table.getRowModel().rows;
+    const virtualItems = this.rowVirtualizer.getVirtualItems();
+    return virtualItems.map(item => this.table.getRowModel().rows[item.index]);
+  }
+
+  flexRender(comp: any, props: any) {
+    return typeof comp === 'function' ? comp(props) : comp;
+  }
+}

--- a/frontend/src/app/datatable/datatable-example.component.ts
+++ b/frontend/src/app/datatable/datatable-example.component.ts
@@ -1,0 +1,44 @@
+import { Component } from '@angular/core';
+import { DataTableComponent } from './data-table.component';
+import { ColumnDef } from '@tanstack/table-core';
+
+interface Person {
+  firstName: string;
+  lastName: string;
+  age: number;
+  visits: number;
+}
+
+@Component({
+  selector: 'app-data-table-example',
+  standalone: true,
+  imports: [DataTableComponent],
+  template: `
+    <app-data-table [data]="data" [columns]="columns"></app-data-table>
+  `,
+})
+export class DataTableExampleComponent {
+  data: Person[] = [
+    { firstName: 'John', lastName: 'Doe', age: 28, visits: 15 },
+    { firstName: 'Jane', lastName: 'Smith', age: 34, visits: 3 },
+    { firstName: 'Alice', lastName: 'Johnson', age: 45, visits: 50 },
+    { firstName: 'Bob', lastName: 'Williams', age: 23, visits: 8 },
+  ];
+
+  columns: ColumnDef<Person, any>[] = [
+    {
+      header: 'Name',
+      columns: [
+        { accessorKey: 'firstName', header: 'First Name' },
+        { accessorKey: 'lastName', header: 'Last Name' },
+      ],
+    },
+    {
+      header: 'Info',
+      columns: [
+        { accessorKey: 'age', header: 'Age' },
+        { accessorKey: 'visits', header: 'Visits' },
+      ],
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- implement `DataTableComponent` using TanStack Table and Virtual packages
- provide example `DataTableExampleComponent`
- register example in the root app
- install TanStack dependencies

## Testing
- `npm test --silent` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_b_6866aaabd338832cbe54b73fff884110